### PR TITLE
Fix NPE when opening brothers page in campaign mode

### DIFF
--- a/HeroPage.cs
+++ b/HeroPage.cs
@@ -201,7 +201,7 @@ namespace EncyclopediaExtender
 
             {
                 var res = new MBBindingList<StringPairItemVM>();
-                if (hero.Clan != null)
+                if (hero.Clan != null && hero.Clan.Leader != null)
                 {
                     var mh = Hero.MainHero;
                     if (MyCanMarry(hero))


### PR DESCRIPTION
This is most likely a taleworlds bug, since your brother ends up with a dangling
`_clan` pointer which will crash the game with an NPE when feed into
MarriageBarterable::GetUnitValueForFaction

Due to DefaultDiplomacyModel::GetHeroCommandingStrengthForClan
having an unguarded access to `hero.Clan.Leader.Father` which will produce the NPE.

So as a guard we can just check if the clan has a leader, since a clan without a leader wouldn't allow for marriage anyway